### PR TITLE
Solo mode

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,4 +25,4 @@ jobs:
       - name: Lint with mypy
         run: mypy targ
       - name: Test with pytest
-        run: pytest targ
+        run: pytest .

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,28 @@
+name: Python package
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r test-requirements.txt
+      - name: Lint with flake8
+        run: flake8 targ
+      - name: Lint with mypy
+        run: mypy targ
+      - name: Test with pytest
+        run: pytest targ

--- a/docs/doc-requirements.txt
+++ b/docs/doc-requirements.txt
@@ -1,3 +1,3 @@
-Sphinx==3.0.1
-sphinx-rtd-theme==0.4.3
-livereload==2.6.1
+Sphinx==3.4.3
+sphinx-rtd-theme==0.5.1
+livereload==2.6.3

--- a/docs/src/cli.rst
+++ b/docs/src/cli.rst
@@ -87,3 +87,29 @@ a problem. To see the full Python traceback, pass in the `trace` argument.
 .. code-block:: bash
 
     python main.py maths add 1 'abc' --trace
+
+Solo mode
+---------
+
+Sometimes you'll just want to register a single command with your CLI, in which
+case, specifying the command name is redundant.
+
+.. code-block:: python
+
+    from targ import CLI
+
+
+    def add(a: int, b: int):
+        print(a + b)
+
+
+    if __name__ == "__main__":
+        cli = CLI()
+        cli.register(add)
+        cli.run(solo=True)
+
+You can then omit the command name:
+
+.. code-block:: bash
+
+    python main.py 1 1

--- a/example_solo_script.py
+++ b/example_solo_script.py
@@ -1,0 +1,19 @@
+from targ import CLI
+
+
+def add(a: int, b: int):
+    """
+    Add the two numbers.
+
+    :param a:
+        The first number.
+    :param b:
+        The second number.
+    """
+    print(a + b)
+
+
+if __name__ == "__main__":
+    cli = CLI()
+    cli.register(add)
+    cli.run(solo=True)

--- a/targ/__init__.py
+++ b/targ/__init__.py
@@ -328,6 +328,7 @@ class CLI:
 
         """
         cleaned_args = self.get_cleaned_args()
+        command: t.Optional[Command] = None
 
         if solo:
             if not self._can_run_in_solo_mode:
@@ -337,7 +338,7 @@ class CLI:
                 )
                 return
             command_name = ""
-            command: t.Optional[Command] = self.commands[0]
+            command = self.commands[0]
             command.solo = True
         else:
             if len(cleaned_args) == 0:

--- a/targ/__init__.py
+++ b/targ/__init__.py
@@ -7,7 +7,7 @@ import sys
 import traceback
 import typing as t
 
-from docstring_parser import parse, Docstring, DocstringParam
+from docstring_parser import parse, Docstring, DocstringParam  # type: ignore
 
 from .format import Color, format_text, get_underline
 

--- a/targ/__init__.py
+++ b/targ/__init__.py
@@ -346,8 +346,9 @@ class CLI:
                 return
 
             command_name = cleaned_args[0]
-            cleaned_args = cleaned_args[1:]
             command = self.get_command(command_name=command_name)
+            if command:
+                cleaned_args = cleaned_args[1:]
 
         if not command:
             # See if it belongs to a group:

--- a/targ/__init__.py
+++ b/targ/__init__.py
@@ -206,8 +206,12 @@ class CLI:
                 return True
         return False
 
-    def _validate_group_name(self, group_name: str) -> bool:
-        if " " in group_name:
+    def _validate_name(self, name: str) -> bool:
+        """
+        Any custom names provided by user should not contain spaces (i.e.
+        command names and group names).
+        """
+        if " " in name:
             return False
         return True
 
@@ -234,8 +238,11 @@ class CLI:
             here.
 
         """
-        if group_name and not self._validate_group_name(group_name):
+        if group_name and not self._validate_name(group_name):
             raise ValueError("The group name should not contain spaces.")
+
+        if command_name and not self._validate_name(command_name):
+            raise ValueError("The command name should not contain spaces.")
 
         self.commands.append(
             Command(

--- a/targ/format.py
+++ b/targ/format.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from enum import Enum
 
-import colorama
+import colorama  # type: ignore
 
 
 colorama.init()

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,1 +1,4 @@
-pytest==5.4.1
+flake8==3.8.4
+mypy==0.800
+pytest-cov==2.11.1
+pytest==6.2.1

--- a/tests/test-coverage.sh
+++ b/tests/test-coverage.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# To run all in a folder tests/
+# To run all in a file tests/test_foo.py
+# To run all in a class tests/test_foo.py::TestFoo
+# To run a single test tests/test_foo.py::TestFoo::test_foo
+
+cd ..
+
+python -m pytest --cov=targ --cov-report html -s $@

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1,13 +1,72 @@
 from unittest import TestCase
+from unittest.mock import MagicMock, patch
+import sys
+import typing as t
 
 from targ import CLI
 
 
+def add(a: int, b: int):
+    print(a + b)
+
+
+def print_(value: t.Any, *args, **kwargs):
+    """
+    When patching the builtin print statement, this is used as a side effect,
+    so we can still use debug statements.
+    """
+    sys.stdout.write(str(value) + "\n")
+    sys.stdout.flush()
+
+
 class CLITest(TestCase):
     def test_register(self):
+        """
+        Make sure a command can be registered.
+        """
         cli = CLI()
 
-        def hello(name: str):
-            print(name)
+        cli.register(add)
 
-        cli.register(hello)
+        self.assertTrue(len(cli.commands) == 1)
+        self.assertTrue(cli.commands[0].command is add)
+
+    @patch("targ.CLI.get_cleaned_args")
+    def test_run(self, get_cleaned_args: MagicMock):
+        """
+        Make sure a command is run correctly.
+        """
+        get_cleaned_args.return_value = ["add", "1", "2"]
+        cli = CLI()
+        cli.register(add)
+
+        with patch("builtins.print", side_effect=print_) as print_mock:
+            cli.run()
+            print_mock.assert_called_with(3)
+
+    @patch("targ.CLI.get_cleaned_args")
+    def test_run_solo(self, get_cleaned_args: MagicMock):
+        """
+        Make sure a command is run correctly, when the CLI is in solo mode.
+        """
+        get_cleaned_args.return_value = ["1", "2"]
+        cli = CLI()
+        cli.register(add)
+
+        with patch("builtins.print", side_effect=print_) as print_mock:
+            cli.run(solo=True)
+            print_mock.assert_called_with(3)
+
+    @patch("targ.CLI.get_cleaned_args")
+    def test_run_group(self, get_cleaned_args: MagicMock):
+        """
+        Make sure a command is run correctly, when the command has been
+        registered in a group.
+        """
+        get_cleaned_args.return_value = ["math", "add", "1", "2"]
+        cli = CLI()
+        cli.register(add, group_name="math")
+
+        with patch("builtins.print", side_effect=print_) as print_mock:
+            cli.run()
+            print_mock.assert_called_with(3)

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -10,6 +10,13 @@ def add(a: int, b: int):
     print(a + b)
 
 
+def greeting(afternoon: bool = False):
+    if afternoon:
+        print("Good afternoon")
+    else:
+        print("Good morning")
+
+
 def print_(value: t.Any, *args, **kwargs):
     """
     When patching the builtin print statement, this is used as a side effect,
@@ -73,16 +80,86 @@ class CLITest(TestCase):
 
     def test_invalid_group_name(self):
         """
-        Make sure a command is run correctly, when the command has been
-        registered in a group.
+        Make sure invalid group names are rejected.
         """
         with self.assertRaises(ValueError):
             CLI().register(add, group_name="contains spaces")
 
-    def test_invalid_app_name(self):
+        # Shouldn't raise an exception
+        CLI().register(add, group_name="my_group")
+
+    def test_invalid_command_name(self):
         """
-        Make sure a command is run correctly, when the command has been
-        registered in a group.
+        Make sure invalid app names are rejected.
         """
         with self.assertRaises(ValueError):
             CLI().register(add, command_name="contains spaces")
+
+        # Shouldn't raise an exception
+        CLI().register(add, command_name="my_command")
+
+    @patch("targ.CLI.get_cleaned_args")
+    def test_no_command(self, get_cleaned_args):
+        """
+        If no command name is given, then help text should be shown.
+        """
+        get_cleaned_args.return_value = []
+        cli = CLI()
+        cli.register(add)
+
+        with patch("targ.CLI.get_help_text") as get_help_text:
+            cli.run()
+            get_help_text.assert_called_once()
+
+        # And just run it once without patching, to make sure no errors
+        # are raised
+        cli.run()
+
+    @patch("targ.CLI.get_cleaned_args")
+    def test_help_flag(self, get_cleaned_args):
+        """
+        If the --help flag is passed in, then help text should be shown.
+        """
+        get_cleaned_args.return_value = ["add", "--help"]
+        cli = CLI()
+        cli.register(add)
+
+        with patch("targ.Command.print_help") as print_help:
+            cli.run()
+            print_help.assert_called_once()
+
+        # And just run it once without patching, to make sure no errors
+        # are raised
+        cli.run()
+
+    @patch("targ.CLI.get_cleaned_args")
+    def test_bool_flag(self, get_cleaned_args):
+        """
+        Test the different formats for boolean flags.
+        """
+        cli = CLI()
+        cli.register(greeting)
+
+        with patch("builtins.print", side_effect=print_) as print_mock:
+            get_cleaned_args.return_value = ["greeting"]
+            cli.run()
+            print_mock.assert_called_with("Good morning")
+
+            for flag in (
+                "--afternoon=f",
+                "--afternoon=false",
+                "--afternoon=False",
+            ):
+                get_cleaned_args.return_value = ["greeting", flag]
+                cli.run()
+                print_mock.assert_called_with("Good morning")
+
+            for flag in (
+                "--afternoon",
+                "--afternoon=t",
+                "--afternoon=true",
+                "--afternoon=True",
+            ):
+                get_cleaned_args.return_value = ["greeting", flag]
+                cli.run()
+                print_mock.assert_called_with("Good afternoon")

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -70,3 +70,19 @@ class CLITest(TestCase):
         with patch("builtins.print", side_effect=print_) as print_mock:
             cli.run()
             print_mock.assert_called_with(3)
+
+    def test_invalid_group_name(self):
+        """
+        Make sure a command is run correctly, when the command has been
+        registered in a group.
+        """
+        with self.assertRaises(ValueError):
+            CLI().register(add, group_name="contains spaces")
+
+    def test_invalid_app_name(self):
+        """
+        Make sure a command is run correctly, when the command has been
+        registered in a group.
+        """
+        with self.assertRaises(ValueError):
+            CLI().register(add, command_name="contains spaces")


### PR DESCRIPTION
Added a solo mode - if a single command is registered with the CLI, then the command name can be omitted.

For example, if we have a command called `add`, we can call it as follows in solo mode:

```
python main.py 1 1
```

Instead of the usual:

```
python main.py add 1 1
```

Having this flexibility is useful when converting an existing CLI script to use Targ.

Also added more unit tests and docstrings.
