### PR TITLE
add support for t.Optional types

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 colorama==0.4.*
 docstring-parser==0.7.1
+typing_inspect==0.6.0; python_version < '3.8'

--- a/targ/__init__.py
+++ b/targ/__init__.py
@@ -9,12 +9,12 @@ import traceback
 import typing as t
 
 try:
-    from t import get_args, get_origin
+    from typing import get_args, get_origin
 except ImportError:
     # For Python 3.7 support
     from typing_extensions import get_args, get_origin
 
-from docstring_parser import parse, Docstring, DocstringParam
+from docstring_parser import parse, Docstring, DocstringParam  # type: ignore
 
 from .format import Color, format_text, get_underline
 

--- a/targ/__init__.py
+++ b/targ/__init__.py
@@ -9,7 +9,7 @@ import traceback
 import typing as t
 
 try:
-    from typing import get_args, get_origin
+    from typing import get_args, get_origin  # type: ignore
 except ImportError:
     # For Python 3.7 support
     from typing_extensions import get_args, get_origin

--- a/targ/__init__.py
+++ b/targ/__init__.py
@@ -8,7 +8,13 @@ import sys
 import traceback
 import typing as t
 
-from docstring_parser import parse, Docstring, DocstringParam  # type: ignore
+try:
+    from t import get_args, get_origin
+except ImportError:
+    # For Python 3.7 support
+    from typing_extensions import get_args, get_origin
+
+from docstring_parser import parse, Docstring, DocstringParam
 
 from .format import Color, format_text, get_underline
 
@@ -186,9 +192,9 @@ class Command:
 
             if annotation in CONVERTABLE_TYPES:
                 value = annotation(value)
-            elif t.get_origin(annotation) is t.Union:
+            elif get_origin(annotation) is t.Union:
                 # t.Union is used to detect t.Optional
-                inner_annotations = t.get_args(annotation)
+                inner_annotations = get_args(annotation)
                 filtered = [i for i in inner_annotations if i is not None]
                 if len(filtered) == 1:
                     annotation = filtered[0]


### PR DESCRIPTION
Annotations like this now work properly:

```python
import typing as t

def my_command(arg1: t.Optional[bool] = None):
    ...
```