### PR TITLE
Aliases

### DIFF
--- a/docs/src/cli.rst
+++ b/docs/src/cli.rst
@@ -51,6 +51,36 @@ You can also register coroutines, as well as normal functions:
       cli.register(timer)
       cli.run()
 
+Aliases
+-------
+
+You can specify aliases for each command, which can make your CLI more
+convenient to use. For example, an alias could be an abbreviation, or a common
+mispelling.
+
+.. code-block:: python
+
+    from targ import CLI
+
+
+    def add(a: int, b: int):
+        print(a + b)
+
+
+    if __name__ == "__main__":
+        cli = CLI()
+        cli.register(add, aliases=['+', 'sum'])
+        cli.run()
+
+Both of the following will now work:
+
+.. code-block:: bash
+
+    python main.py add 1 1
+    python main.py + 1 1
+    python main.py sum 1 1
+
+
 Groups
 ------
 

--- a/example_script.py
+++ b/example_script.py
@@ -135,7 +135,7 @@ if __name__ == "__main__":
     cli = CLI()
     cli.register(say_hello)
     cli.register(echo)
-    cli.register(add)
+    cli.register(add, aliases=["+"])
     cli.register(print_pi)
     cli.register(compound_interest)
     cli.register(compound_interest_decimal)

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -412,3 +412,28 @@ class CLITest(TestCase):
                 cli.run()
                 print_mock.assert_called_with(config.output)
                 print_mock.reset_mock()
+
+    @patch("targ.CLI.get_cleaned_args")
+    def test_aliases(self, get_cleaned_args):
+        """
+        Make sure commands with aliases can be called correctlyy.
+        """
+
+        def test_command():
+            print("Command called")
+
+        cli = CLI()
+        cli.register(test_command, aliases=["tc"])
+
+        with patch("builtins.print", side_effect=print_) as print_mock:
+
+            configs: t.List[Config] = [
+                Config(params=["test_command"], output="Command called"),
+                Config(params=["tc"], output="Command called"),
+            ]
+
+            for config in configs:
+                get_cleaned_args.return_value = config.params
+                cli.run()
+                print_mock.assert_called_with(config.output)
+                print_mock.reset_mock()


### PR DESCRIPTION
Aliases can now be provided for commands. Examples are abbreviations or misspellings.

```python
from targ import CLI


def add(a: int, b: int):
    print(a + b)


if __name__ == "__main__":
    cli = CLI()
    cli.register(add, aliases=['+', 'sum'])
    cli.run()
```