### PR TITLE
Docstrings and trace

### DIFF
--- a/example_script.py
+++ b/example_script.py
@@ -131,6 +131,14 @@ async def timer(seconds: int):
     print("Finished")
 
 
+def raise_error():
+    """
+    A command which raises an Exception.
+    """
+    print("Raising an exception")
+    raise ValueError("Something went wrong!")
+
+
 if __name__ == "__main__":
     cli = CLI()
     cli.register(say_hello)
@@ -143,4 +151,5 @@ if __name__ == "__main__":
     cli.register(timer)
     cli.register(add, command_name="sum")
     cli.register(print_address)
+    cli.register(raise_error)
     cli.run()

--- a/targ/__init__.py
+++ b/targ/__init__.py
@@ -35,6 +35,24 @@ class Arguments:
 
 @dataclass
 class Command:
+    """
+    Represents a CLI command.
+
+    :param command:
+        The Pyton function or coroutine which gets called.
+    :param group_name:
+        Commands can belong to a group. In this situation, the group name must
+        appear before the command name when called from the command line. For
+        example `python my_file.py group_name command_name`.
+    :param command_name:
+        By default the command name is the same as the callable, but it can
+        be overriden here.
+    :param aliases:
+        You can provide aliases, which can be abbreviations or common
+        mispellings. For example, for a `command_name` of ``run``, we could
+        have aliases like ``['start', 'rn']``.
+
+    """
     command: t.Callable
     group_name: t.Optional[str] = None
     command_name: t.Optional[str] = None

--- a/targ/__init__.py
+++ b/targ/__init__.py
@@ -452,6 +452,8 @@ class CLI:
 
                 if trace:
                     print(traceback.format_exc())
+                else:
+                    print("For a full stack trace, use --trace")
 
                 command.print_help()
                 sys.exit(1)


### PR DESCRIPTION
Fixing two issues:

 * `Command` had no docstring
 * Telling users about `--trace` if a command fails